### PR TITLE
stream version of sha256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ GTAGS
 .vscode
 .vs
 
-ext/win64/
-
+ext/Darwin_arm64
+ext/Darwin_amd64
+ext/Linux_aarch64

--- a/src/cpp/sha256.hpp.md
+++ b/src/cpp/sha256.hpp.md
@@ -6,9 +6,10 @@
 
 #pragma once
 
-#include "lxr/key256.hpp"
 #include <filesystem>
-#include <functional>
+
+#include "lxr/key256.hpp"
+#include "sizebounded/sizebounded.hpp"
 
 ````
 
@@ -48,11 +49,21 @@ namespace [lxr](namespace.list) {
 
 >static Key256 [hash](sha256_functions.cpp.md)(std::filesystem::path const &);
 
->protected:
+>Sha256();
 
->Sha256() {}
+>~Sha256();
+
+>static constexpr unsigned int datasz { 1024*64 };
+
+>int [process](sha256_functions.cpp.md)(int inlen, sizebounded&lt;unsigned char, Sha256::datasz&gt; const & inbuf);
+
+>Key256 [finish](sha256_functions.cpp.md)();
 
 >private:
+
+>struct pimpl;
+
+>std::unique_ptr&lt;pimpl&gt; _pimpl;
 
 >Sha256(Sha256 const &) = delete;
 

--- a/src/cpp/sha256_-alpha-.md
+++ b/src/cpp/sha256_-alpha-.md
@@ -6,15 +6,30 @@
 */
 
 #include <cassert>
+#include <functional>
 
 #include "lxr/sha256.hpp"
+#include "sizebounded/sizebounded.ipp"
 
 #if CRYPTOLIB == OPENSSL
 #include "openssl/evp.h"
 #include "openssl/sha.h"
+
+struct lxr::Sha256::pimpl {
+    const EVP_MD *md = EVP_sha3_256();
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(ctx, md, nullptr);
+};
+
 #endif
+
 #if CRYPTOLIB == CRYPTOPP
 #include "cryptopp/sha3.h"
+
+struct lxr::Sha256::pimpl {
+    CryptoPP::SHA3_256 hash;
+};
+
 #endif
 
 #include <fstream>

--- a/src/cpp/sha256_functions.cpp.md
+++ b/src/cpp/sha256_functions.cpp.md
@@ -2,5 +2,20 @@ declared in [Sha256](sha256.hpp.md)
 
 ```cpp
 
+Sha256::Sha256()
+    : _pimpl(new Sha256::pimpl)
+{
+}
 
+Sha256::~Sha256()
+{
+    if (_pimpl) {
+        _pimpl.reset();
+    }
+}
+
+Key256 Sha256::hash(std::string const & msg)
+{
+    return Sha256::hash(msg.c_str(), msg.size());
+}
 ```

--- a/src/cpp/sha256_openssl.cpp.md
+++ b/src/cpp/sha256_openssl.cpp.md
@@ -3,11 +3,6 @@ declared in [Sha256](sha256.hpp.md)
 ```cpp
 
 #if CRYPTOLIB == OPENSSL
-Key256 Sha256::hash(std::string const & msg)
-{
-    return Sha256::hash(msg.c_str(), msg.size());
-}
-
 Key256 Sha256::hash(const char buffer[], int length)
 {
     unsigned char digest[SHA256_DIGEST_LENGTH];
@@ -26,21 +21,33 @@ Key256 Sha256::hash(const char buffer[], int length)
 
 Key256 Sha256::hash(std::filesystem::path const & fpath)
 {
-    unsigned char digest[SHA256_DIGEST_LENGTH];
-    const EVP_MD *md = EVP_sha3_256();
-    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-    EVP_DigestInit_ex(ctx, md, nullptr);
-
-    Key256 k(true);
-    unsigned char buf[1024];
+    Sha256 sha256;
+    sizebounded<unsigned char, Sha256::datasz> buf;
     std::filesystem::ifstream infile(fpath);
     while (infile.good()) {
-        infile.read((char*)buf, 1024);
-        EVP_DigestUpdate(ctx, buf, infile.gcount());
+        infile.read((char*)buf.ptr(), Sha256::datasz);
+        sha256.process(infile.gcount(), buf);
     }
-    EVP_DigestFinal_ex(ctx, digest, nullptr);
     k.fromBytes(digest);
-    EVP_MD_CTX_free(ctx);
+    return sha256.finish();
+}
+
+int Sha256::process(int len, sizebounded<unsigned char, Sha256::datasz> const & buf)
+{
+    if (len <= Sha256::datasz) {
+        EVP_DigestUpdate(_pimpl->ctx, buf->ptr(), len);
+        return len;
+    }
+    return 0;
+}
+
+Key256 Sha256::finish()
+{
+    unsigned char digest[SHA256_DIGEST_LENGTH];
+    EVP_DigestFinal_ex(_pimpl->ctx, digest, nullptr);
+    Key256 k(true);
+    k.fromBytes(digest);
+    EVP_MD_CTX_free(_pimpl->ctx);
     return k;
 }
 #endif


### PR DESCRIPTION
a stream of data updates can be subjected to hashing with Sha256.
each chunk of data can have up to 64k bytes.